### PR TITLE
vk_rasterizer: Restore FlushRegion in FlushAndInvalidateRegion

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -798,6 +798,9 @@ void RasterizerVulkan::ReleaseFences(bool force) {
 
 void RasterizerVulkan::FlushAndInvalidateRegion(DAddr addr, u64 size,
                                                 VideoCommon::CacheType which) {
+    if (Settings::IsGPULevelExtreme()) {
+        FlushRegion(addr, size, which);
+    }
     InvalidateRegion(addr, size, which);
 }
 


### PR DESCRIPTION
## Summary

Restores the `FlushRegion` call in `FlushAndInvalidateRegion` that was removed from the original Yuzu codebase, gated behind `IsGPULevelExtreme()`.

## The Problem

Games that read back the framebuffer during scene transitions get black screens because GPU-rendered data is never flushed back to CPU-accessible memory before invalidation.

**Before (Eden - broken):**
```cpp
void RasterizerVulkan::FlushAndInvalidateRegion(...) {
    InvalidateRegion(addr, size, which);
}
```

**After (this PR - matches original Yuzu and Citron):**
```cpp
void RasterizerVulkan::FlushAndInvalidateRegion(...) {
    if (Settings::IsGPULevelExtreme()) {
        FlushRegion(addr, size, which);
    }
    InvalidateRegion(addr, size, which);
}
```

## Performance Impact

**Zero** at Normal/High GPU accuracy. The flush only executes when the user explicitly sets GPU accuracy to Extreme, which is the same tradeoff the original Yuzu made.

## Affected Games

- **Paper Mario: The Thousand-Year Door** [0100ECD018EBE000] — black screen flash during boat flip (prologue), bridge building (Chapter 1), and other framebuffer readback transitions
- Potentially any game that performs render-to-texture transitions

## Verification

- Compared Eden's `vk_rasterizer.cpp` against original Yuzu and Citron fork
- Both original Yuzu and Citron have this `FlushRegion` call present
- The bug is documented in Issue-Reports#425 and Issue-Reports#266

## Test Plan

- [ ] Launch Paper Mario TTYD with GPU accuracy set to Extreme
- [ ] Verify boat flip transition in prologue shows proper animation instead of black flash
- [ ] Verify bridge building in Chapter 1 renders correctly
- [ ] Verify no performance regression at Normal/High GPU accuracy