### PR TITLE
[android] Fix swkbd inline keyboard submitting before appearing

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/applets/keyboard/SoftwareKeyboard.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/applets/keyboard/SoftwareKeyboard.kt
@@ -46,12 +46,20 @@ object SoftwareKeyboard {
         // There isn't a good way to know that the IMM is dismissed, so poll every 500ms to submit inline keyboard result.
         val handler = Handler(Looper.myLooper()!!)
         val delayMs = 500
+        var keyboardEverShown = false
         handler.postDelayed(
             object : Runnable {
                 override fun run() {
                     val insets = ViewCompat.getRootWindowInsets(overlayView)
-                    val isKeyboardVisible = insets!!.isVisible(WindowInsets.Type.ime())
+                    val isKeyboardVisible = insets?.isVisible(WindowInsets.Type.ime()) == true
                     if (isKeyboardVisible) {
+                        keyboardEverShown = true
+                        handler.postDelayed(this, delayMs.toLong())
+                        return
+                    }
+
+                    if (!keyboardEverShown) {
+                        // Keyboard hasn't appeared yet; keep polling instead of submitting empty input.
                         handler.postDelayed(this, delayMs.toLong())
                         return
                     }


### PR DESCRIPTION
## Problem
The Android inline software keyboard polls every 500ms to detect when the IMM is dismissed. On the first tick, if the keyboard hasn't appeared yet, \insets!!.isVisible()\ returns false and the handler immediately sends \KEYCODE_ENTER\ with empty text — causing an infinite loop in games like Tomodachi Life: Living the Dream that wait for text input.

## Fix
Add a \keyboardEverShown\ flag. The handler keeps polling until the keyboard has been observed as visible at least once, then only submits after it disappears. Also replaces the force-unwrap \insets!!\ with a safe \insets?.\ call.

## Testing
Tested on Tomodachi Life: Living the Dream — keyboard now waits for user input before submitting.