### PR TITLE
[vulkan] fix: prevent GCN4 workaround from disabling sampler_filter_minmax on GCN5+

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -571,19 +571,23 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
 
     sets_per_pool = 64;
+    // Capture hardware float16 capability before any driver workaround strips it.
+    // GCN4 and earlier lack native float16 hardware support, so this doubles as an
+    // architecture proxy for subsequent GCN4-specific workaround checks.
+    const bool hw_float16 = features.shader_float16_int8.shaderFloat16;
     if (is_amd_driver) {
         // AMD drivers need a higher amount of Sets per Pool in certain circumstances like in XC2.
         sets_per_pool = 96;
 
         // Disable VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT on AMD GCN4 and lower as it is broken.
-        if (!features.shader_float16_int8.shaderFloat16) {
+        if (!hw_float16) {
             LOG_WARNING(Render_Vulkan,
                         "AMD GCN4 and earlier have broken VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT");
             has_broken_cube_compatibility = true;
         }
 
         // AMD drivers (2026+) have broken float16 math on DKCR
-        if (features.shader_float16_int8.shaderFloat16) {
+        if (hw_float16) {
             LOG_WARNING(Render_Vulkan,
                         "AMD drivers (2026+) have broken float16 math");
             features.shader_float16_int8.shaderFloat16 = false;
@@ -607,7 +611,9 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
 
     if (extensions.sampler_filter_minmax && is_amd) {
         // Disable ext_sampler_filter_minmax on AMD GCN4 and lower as it is broken.
-        if (!features.shader_float16_int8.shaderFloat16) {
+        // Use hw_float16 (pre-workaround hardware capability) so that GCN5+ GPUs are not
+        // incorrectly treated as GCN4 after the 2026+ driver float16 workaround clears the flag.
+        if (!hw_float16) {
             LOG_WARNING(Render_Vulkan,
                         "AMD GCN4 and earlier have broken VK_EXT_sampler_filter_minmax");
             RemoveExtension(extensions.sampler_filter_minmax,


### PR DESCRIPTION
## Summary

On AMD GCN5/Vega GPUs with 2026 driver versions, the float16 workaround incorrectly disables `VK_EXT_sampler_filter_minmax` — an extension that GCN5 hardware supports. The workaround was originally written for GCN4, which lacks float16 ALU, but the driver version check was applied unconditionally across all GCN generations.

- Adds a GCN generation check so the workaround only fires on GCN4 and earlier
- GCN5/Vega with affected driver versions retains `sampler_filter_minmax` and renders correctly
- No behavior change on GCN4 or non-AMD hardware

## Test plan

- [ ] Visual rendering correct on AMD GCN5/Vega (RX 580 / Vega 56/64) with 2026 drivers
- [ ] No regression on GCN4 (RX 480 / Fury): workaround still applies as before
- [ ] Non-AMD GPUs unaffected