### PR TITLE
Fix application state notification

### DIFF
--- a/src/core/hle/service/am/lifecycle_manager.cpp
+++ b/src/core/hle/service/am/lifecycle_manager.cpp
@@ -372,6 +372,10 @@ bool LifecycleManager::UpdateRequestedFocusState() {
         // Mark the focus state as ready for update.
         m_requested_focus_state = new_state;
 
+        if (m_is_application) {
+            m_has_focus_state_changed = true;
+        }
+
         // We changed the focus state.
         return true;
     }


### PR DESCRIPTION
This fixed issues in Mario Kart 8 multiplayer where the native controller applet would pop up, then once A was pressed and it exited, it would freeze the game but music would continue playing.

The issue was that `UpdateRequestedFocusState()` updates the focus state but never sets `m_has_focus_state_changed` for applications. Since `ShouldSignalSystemEvent()` checks that flag for applications, they never receive `FocusStateChanged` messages when LLE library applets exit. The game keeps running (hence the music) but is stuck waiting for a focus notification that never arrives. HLE applets aren't affected because their dummy process has `is_process_running=false`, so the game is never considered obscured in the first place.