### PR TITLE
Return ResultPathAlreadyExists from CreateDirectory if path exists

### DIFF
--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -97,7 +97,9 @@ Result VfsDirectoryServiceWrapper::DeleteFile(const std::string& path_) const {
 
 Result VfsDirectoryServiceWrapper::CreateDirectory(const std::string& path_) const {
     std::string path(Common::FS::SanitizePath(path_));
-
+    if (GetDirectoryRelativeWrapped(backing, path) != nullptr) {
+        return FileSys::ResultPathAlreadyExists;
+    }
     // NOTE: This is inaccurate behavior. CreateDirectory is not recursive.
     // CreateDirectory should return PathNotFound if the parent directory does not exist.
     // This is here temporarily in order to have UMM "work" in the meantime.


### PR DESCRIPTION
Returning success when the path already exists confuses games like Eastward which use this result in their save logic.

It's possible that the recursive directory creation marked as "inaccurate" below could be removed with this fix but that is untested. Since games can use the result to control their save logic the recursive creation may have been compensating for the same issue but in a way that works for some games but not others like Eastward.

Eastward behaviour without this fix, leads to missing "slot<n>" folders: 
```
[147.629] GetEntryType /SaveData/slot1/player.info → PathNotFound  (save attempt begins)
[147.629] GetEntryType /SaveData/slot2/player.info → PathNotFound
[147.630] GetEntryType /SaveData/slot3/player.info → PathNotFound
[147.630] GetEntryType /SaveData/slot4/player.info → PathNotFound
[147.631] GetEntryType /SaveData/slot5/player.info → PathNotFound
[147.631] GetEntryType /SaveData/slot6/player.info → PathNotFound
[149.235] GetEntryType /                            → Directory
[149.236] GetEntryType /SaveData/slot1              → PathNotFound
[149.250] CreateDirectory /SaveData                 → Success (newly created)
[149.254] GetEntryType /SaveData/slot1              → PathNotFound
[149.283] GetEntryType /                            → Directory
[149.284] GetEntryType /SaveData/slot1              → PathNotFound
[149.284] CreateDirectory /SaveData                 → Success ★ (BUG — should be PathAlreadyExists)
[149.284] GetEntryType /SaveData/slot1              → PathNotFound (still)
... game gives up — never calls CreateDirectory /SaveData/slot1
... never calls OpenFile or CreateFile on player.info
... no save written, no error surfaced
```

Eastward behaviour with this fix:
```
[115.465] GetEntryType /SaveData/slot1/player.info → PathNotFound  (save attempt begins)
[115.465] GetEntryType /SaveData/slot2/player.info → PathNotFound
[115.466] GetEntryType /SaveData/slot3/player.info → PathNotFound
[115.466] GetEntryType /SaveData/slot4/player.info → PathNotFound
[115.467] GetEntryType /SaveData/slot5/player.info → PathNotFound
[115.467] GetEntryType /SaveData/slot6/player.info → PathNotFound
[116.796] GetEntryType /                            → Directory
[116.796] GetEntryType /SaveData/slot1              → PathNotFound
[116.810] CreateDirectory /SaveData                 → Success (newly created)
[116.814] GetEntryType /SaveData/slot1              → PathNotFound
[116.843] GetEntryType /                            → Directory
[116.843] GetEntryType /SaveData/slot1              → PathNotFound
[116.844] CreateDirectory /SaveData                 → PathAlreadyExists ★  (Fixes the BUG)
[116.845] CreateDirectory /SaveData/slot1           ← game's slot-create branch fires
[116.845] GetEntryType /SaveData/slot1              → Directory
[116.860] GetEntryType /SaveData/slot1/player.info  → PathNotFound
[116.861] CreateDirectory /SaveData                 → PathAlreadyExists
[116.863] CreateDirectory /SaveData/slot1           → PathAlreadyExists
[116.865] GetEntryType /SaveData/slot1/player.info  → PathNotFound
[116.867] OpenFile  /SaveData/slot1/player.info mode=7 → fails (file missing)
[116.876] CreateFile /SaveData/slot1/player.info    → Success ★
[116.881] OpenFile  /SaveData/slot1/player.info mode=7 → Success
```