### PR TITLE
Support Joy-Con D-pad buttons

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/InputDialogFragment.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/InputDialogFragment.kt
@@ -169,7 +169,7 @@ class InputDialogFragment : DialogFragment() {
         NativeInput.onGamePadButtonEvent(
             controllerData.getGUID(),
             controllerData.getPort(),
-            event.keyCode,
+            InputHandler.getButtonIdFromEvent(event),
             action
         )
         onInputReceived(event.device)

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/InputHandler.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/InputHandler.kt
@@ -49,6 +49,12 @@ object InputHandler {
         MotionEvent.AXIS_RTRIGGER
     )
 
+    // Currently, Android doesn't support Joy-Con D-pad buttons. We fall back to the scan code
+    private const val LINUX_BUTTON_DPAD_UP = 0x220
+    private const val LINUX_BUTTON_DPAD_DOWN = 0x221
+    private const val LINUX_BUTTON_DPAD_LEFT = 0x222
+    private const val LINUX_BUTTON_DPAD_RIGHT = 0x223
+
     fun isPhysicalGameController(device: InputDevice?): Boolean {
         device ?: return false
 
@@ -87,10 +93,23 @@ object InputHandler {
         NativeInput.onGamePadButtonEvent(
             controllerData.getGUID(),
             controllerData.getPort(),
-            event.keyCode,
+            getButtonIdFromEvent(event),
             action
         )
         return true
+    }
+
+    fun getButtonIdFromEvent(event: KeyEvent): Int {
+        if (event.keyCode == 0) {
+            return when (event.scanCode) {
+                LINUX_BUTTON_DPAD_UP -> KeyEvent.KEYCODE_DPAD_UP
+                LINUX_BUTTON_DPAD_DOWN -> KeyEvent.KEYCODE_DPAD_DOWN
+                LINUX_BUTTON_DPAD_LEFT -> KeyEvent.KEYCODE_DPAD_LEFT
+                LINUX_BUTTON_DPAD_RIGHT -> KeyEvent.KEYCODE_DPAD_RIGHT
+                else -> return 0
+            }
+        }
+        return event.keyCode
     }
 
     fun dispatchGenericMotionEvent(event: MotionEvent): Boolean {

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/InputHandler.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/utils/InputHandler.kt
@@ -100,7 +100,9 @@ object InputHandler {
     }
 
     fun getButtonIdFromEvent(event: KeyEvent): Int {
-        if (event.keyCode == 0) {
+        val isLeftJoyCon = event.device.vendorId == 0x057e && event.device.productId == 0x2006
+
+        if (event.keyCode == 0 && isLeftJoyCon) {
             return when (event.scanCode) {
                 LINUX_BUTTON_DPAD_UP -> KeyEvent.KEYCODE_DPAD_UP
                 LINUX_BUTTON_DPAD_DOWN -> KeyEvent.KEYCODE_DPAD_DOWN

--- a/src/input_common/drivers/android.cpp
+++ b/src/input_common/drivers/android.cpp
@@ -219,9 +219,15 @@ ButtonMapping Android::GetButtonMappingForDevice(const Common::ParamPackage& par
     jboolean isCopy = false;
     jboolean* j_has_keys = env->GetBooleanArrayElements(j_has_keys_object, &isCopy);
 
+    auto j_yuzu_device_name = (jstring)env->CallObjectMethod(j_device, Common::Android::GetYuzuDeviceGetName());
+    const char *yuzu_device_name = env->GetStringUTFChars(j_yuzu_device_name, &isCopy);
+    const char *left_joyCon_string_name = "Nintendo Switch Left Joy-Con";
+    bool is_left_joyCon = strncmp(yuzu_device_name, left_joyCon_string_name, strlen(left_joyCon_string_name)) == 0;
+    env->ReleaseStringUTFChars(j_yuzu_device_name, yuzu_device_name);
+
     std::set<s32> available_keys;
     for (size_t i = 0; i < keycode_ids.size(); ++i) {
-        if (j_has_keys[i]) {
+        if (j_has_keys[i] || (is_left_joyCon && i <= 3)) {
             available_keys.insert(keycode_ids[i]);
         }
     }


### PR DESCRIPTION
This PR fixes both eden-emulator/Issue-Reports#8 and eden-emulator/Issue-Reports#428.

Currently, [Android's input layer](https://android.googlesource.com/platform/frameworks/base.git/+/refs/heads/android16-release/data/keyboards/Vendor_057e_Product_2009.kl#54) doesn't return `KEYCODE_DPAD_*` for the left Joy-Con, we fall back to the scan code in this case, this will also fix most third party Joy-Con controllers.

### (Potential) issues and fixes:

- The scan codes are not reliable and may vary from device to another. I searched for (0x220-0x223) values in the [android repo](https://android.googlesource.com/platform/frameworks/base.git/+/refs/heads/android16-release/data/keyboards) and they all have the same DPAD_* key mapping, so not a big issue just might cause future issues if Google change the mapping in another vendor. I could simply limit the fix to the [left Joy-Con](https://github.com/torvalds/linux/blob/master/drivers/hid/hid-ids.h#L1096-L1105) `if (event.keyCode == 0 && event.device.vendorId == 0x057e && event.device.productId == 0x2006)`.
- Auto mapping doesn't work, I'm not very familiar with the JNI Specification, I managed to implement the below workaround, it basically checks if it's the left Joy-Con and add the first four DPAD_* keycodes 
  ```cpp
  // ./src/input_common/drivers/android.cpp
  ButtonMapping Android::GetButtonMappingForDevice(const Common::ParamPackage& params) {
      // ...
      const char *yuzu_device_name = env->GetStringUTFChars((jstring) env->CallObjectMethod(j_device, Common::Android::GetYuzuDeviceGetName()), &isCopy);
      const char *switch_left_string_name = "Nintendo Switch Left Joy-Con";
      bool is_switch_left = strncmp(yuzu_device_name, switch_left_string_name, strlen(switch_left_string_name)) == 0;
  
      std::set<s32> available_keys;
      for (size_t i = 0; i < keycode_ids.size(); ++i) {
          if (j_has_keys[i] || (is_switch_left && i <= 3)) {
              available_keys.insert(keycode_ids[i]);
          }
      }
      // ...
  }
  ```

Let me know if I should add those modifications.