### PR TITLE
Add setting to disable depth of field clamping

### DIFF
--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/BooleanSetting.kt
@@ -17,6 +17,7 @@ enum class BooleanSetting(override val key: String) : AbstractBooleanSetting {
     USE_CUSTOM_CPU_TICKS("use_custom_cpu_ticks"),
     SKIP_CPU_INNER_INVALIDATION("skip_cpu_inner_invalidation"),
     FIX_BLOOM_EFFECTS("fix_bloom_effects"),
+    FORCE_UNRESTRICTED_DEPTH("force_unrestricted_depth"),
     EMULATE_BGR565("emulate_bgr565"),
     RESCALE_HACK("rescale_hack"),
     CPUOPT_UNSAFE_HOST_MMU("cpuopt_unsafe_host_mmu"),

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/model/view/SettingsItem.kt
@@ -775,6 +775,13 @@ abstract class SettingsItem(
             )
             put(
                 SwitchSetting(
+                    BooleanSetting.FORCE_UNRESTRICTED_DEPTH,
+                    titleId = R.string.force_unrestricted_depth,
+                    descriptionId = R.string.force_unrestricted_depth_description
+                )
+            )
+            put(
+                SwitchSetting(
                     BooleanSetting.RESCALE_HACK,
                     titleId = R.string.rescale_hack,
                     descriptionId = R.string.rescale_hack_description

--- a/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/yuzu/yuzu_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -301,6 +301,7 @@ class SettingsFragmentPresenter(
             add(IntSetting.FAST_GPU_TIME.key)
             add(BooleanSetting.SKIP_CPU_INNER_INVALIDATION.key)
             add(BooleanSetting.FIX_BLOOM_EFFECTS.key)
+            add(BooleanSetting.FORCE_UNRESTRICTED_DEPTH.key)
             add(BooleanSetting.EMULATE_BGR565.key)
             add(BooleanSetting.RESCALE_HACK.key)
             add(BooleanSetting.RENDERER_ASYNCHRONOUS_SHADERS.key)

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -518,6 +518,8 @@
     <string name="skip_cpu_inner_invalidation_description">Skips certain CPU-side cache invalidations during memory updates, reducing CPU usage and improving it\'s performance. This may cause glitches or crashes on some games.</string>
     <string name="fix_bloom_effects">Fix Bloom Effects</string>
     <string name="fix_bloom_effects_description">Reduces bloom blur in LA/EOW (Adreno A6XX - A7XX/ Turnip), removes bloom in Burnout. Warning: may cause graphical artifacts in other games.</string>
+    <string name="force_unrestricted_depth">Force Unrestricted Depth Range</string>
+    <string name="force_unrestricted_depth_description">Stops clamping the viewport depth range on drivers that lack VK_EXT_depth_range_unrestricted. May fix blurriness in some games.</string>
     <string name="emulate_bgr565">Emulate BGR565</string>
     <string name="emulate_bgr565_description">Fixes problems with inverted colors in games or strange artifacts or strange shadows.</string>
     <string name="rescale_hack">Enable Legacy Rescale Pass</string>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -566,6 +566,9 @@ struct Values {
     SwitchableSetting<bool> fix_bloom_effects{linkage, false, "fix_bloom_effects",
                                                      Category::RendererHacks};
 
+    SwitchableSetting<bool> force_unrestricted_depth{linkage, false, "force_unrestricted_depth",
+                                                     Category::RendererHacks};
+
     SwitchableSetting<bool> emulate_bgr565{linkage, false, "emulate_bgr565",
                                             Category::RendererHacks};
 

--- a/src/qt_common/config/shared_translation.cpp
+++ b/src/qt_common/config/shared_translation.cpp
@@ -272,6 +272,10 @@ std::unique_ptr<TranslationMap> InitializeTranslations(QObject* parent) {
               "quality and performance consistency in some games."));
     INSERT(Settings, fix_bloom_effects, tr("Fix bloom effects"), tr("Removes bloom in Burnout."));
 
+    INSERT(Settings, force_unrestricted_depth, tr("Force Unrestricted Depth Range"),
+           tr("Stops clamping the viewport depth range on drivers that lack "
+              "VK_EXT_depth_range_unrestricted. May fix blurriness in some games."));
+
     INSERT(Settings, rescale_hack, tr("Enable Legacy Rescale Pass"),
            tr("May fix rescale issues in some games by relying on behavior from the previous "
               "implementation.\n"

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -101,7 +101,7 @@ VkViewport GetViewportState(const Device& device, const Maxwell& regs, size_t in
         .minDepth = src.translate_z - src.scale_z * reduce_z,
         .maxDepth = src.translate_z + src.scale_z,
     };
-    if (!device.IsExtDepthRangeUnrestrictedSupported()) {
+    if (!device.IsExtDepthRangeUnrestrictedSupported() && !Settings::values.force_unrestricted_depth.GetValue()) {
         viewport.minDepth = std::clamp(viewport.minDepth, 0.0f, 1.0f);
         viewport.maxDepth = std::clamp(viewport.maxDepth, 0.0f, 1.0f);
     }


### PR DESCRIPTION
Fixes blurry sprites in The Hundred Line -Last Defense Academy-

- [x] I have read and followed the [Contribution Guidelines](https://git.eden-emu.dev/eden-emu/eden/src/branch/master/CONTRIBUTING.md#code-contributions).
- [X] I have read and followed the [AI Policy](https://git.eden-emu.dev/eden-emu/eden/src/branch/master/docs/policies/AI.md)
- [X] I have read and followed the [Coding Guidelines](https://git.eden-emu.dev/eden-emu/eden/src/branch/master/docs/policies/Coding.md) to the best of my ability.

Camille LaVey mentioned on Discord that this option might have a performance impact on BOTW, but I haven't tested it.